### PR TITLE
Add support MySQL 8 on all server version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     api 'com.zaxxer:HikariCP:4.0.3'
     api 'org.slf4j:slf4j-api:1.7.32'
     api 'org.slf4j:slf4j-nop:1.7.32'
+    api 'mysql:mysql-connector-java:8.0.29'
 }
 
 task processSource(type: Sync) {
@@ -55,6 +56,7 @@ shadowJar {
     relocate('com.zaxxer.hikari', 'dev.rosewood.rosegarden.lib.hikaricp')
     relocate('org.slf4j', 'dev.rosewood.rosegarden.lib.slf4j')
     relocate('org.bstats', 'dev.rosewood.rosegarden.lib.bstats')
+    relocate('com.mysql', 'dev.rosewood.rosegarden.lib.mysql')
 }
 
 publishing {

--- a/src/main/java/dev/rosewood/rosegarden/database/MySQLConnector.java
+++ b/src/main/java/dev/rosewood/rosegarden/database/MySQLConnector.java
@@ -20,6 +20,7 @@ public class MySQLConnector implements DatabaseConnector {
         this.lock = new Object();
 
         HikariConfig config = new HikariConfig();
+        config.setDriverClassName("com.mysql.cj.jdbc.Driver");
         config.setJdbcUrl("jdbc:mysql://" + hostname + ":" + port + "/" + database + "?useSSL=" + useSSL + "&allowPublicKeyRetrieval=true&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8");
         config.setUsername(username);
         config.setPassword(password);


### PR DESCRIPTION
So i added MySQL 8 on all server version and it worked on Spigot 1.8.8 and upper on that so it not using MySQL Driver on Spigot anymore anyways, also on PlayerPoints or other plugin, you should remove minimize() on ShadowJar
That's all
Thanks!