### PR TITLE
Fixed World::getName incompatibility

### DIFF
--- a/Core/src/main/java/dev/rosewood/rosegarden/config/SettingSerializers.java
+++ b/Core/src/main/java/dev/rosewood/rosegarden/config/SettingSerializers.java
@@ -106,7 +106,7 @@ public final class SettingSerializers {
         public ConfigurationSection read(ConfigurationSection config, String key) { return config.getConfigurationSection(key); }
     };
 
-    public static final SettingSerializer<World> WORLD = new BaseSettingSerializer<World>(World.class, World::getName, Bukkit::getWorld) {
+    public static final SettingSerializer<World> WORLD = new BaseSettingSerializer<World>(World.class, world -> world.getName(), Bukkit::getWorld) {
         public void write(ConfigurationSection config, String key, World value, String... comments) { setWithComments(config, key, value, comments); }
         public World read(ConfigurationSection config, String key) {
             String worldName = config.getString(key);


### PR DESCRIPTION
Hello,
today I updated PlayerParticles to v8.12 and the plugin failed to load:
```txt
[19:07:53] [Server thread/ERROR]: Error occurred while enabling PlayerParticles v8.12 (Is it up to date?)
java.lang.NoClassDefFoundError: org/bukkit/generator/WorldInfo
	at dev.esophose.playerparticles.libs.rosegarden.config.SettingSerializers.<clinit>(SettingSerializers.java:111) ~[?:?]
# rest is unrelevant
```
v8.13-SNAPSHOT produced the same error. It seems that the `WorldInfo` interface got added with a 1.17.1 snapshot and `World`'s `getName()` method is from that interface now, so `World::getName` cannot be used anymore on older versions. [I've had exactly the same problem with my plugin some time ago](https://github.com/ChatPlugin/ChatPlugin/commit/6c78169af5a430803fe23832d499b0a8993683c2) and explicitly calling the method was enough; I think it's the easiest solution.